### PR TITLE
Fix delete quota command

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -487,5 +487,5 @@ EOF
 Make sure you don't forget to delete the quota before moving on:
 
 ```
-kubectl delete resource quota pods-limit
+kubectl delete quota pods-limit
 ```


### PR DESCRIPTION
This fixes a delete resource quota command:

`$ kubectl delete resource quota pods-limit  # current`
>error: the server doesn't have a resource type "resource"

`$ kubectl delete quota pods-limit  # as it should be`
>resourcequota "pods-limit" deleted